### PR TITLE
Elastic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository holds code for a prototype service looking at ways to integrate 
 It is unlinkely to be of value to others outside this organization.
 
 
+## Running elastic search on development machine
+
+  docker pull docker.elastic.co/elasticsearch/elasticsearch:7.5.1
+  docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.5.1

--- a/cmd/annote-server/main.go
+++ b/cmd/annote-server/main.go
@@ -22,6 +22,7 @@ type Config struct {
 	ImageViewerHost       string
 	Hostname              string
 	UploadPath            string
+	ElasticSearchURL      string
 }
 
 var (
@@ -65,6 +66,7 @@ func main() {
 	}
 	annote.CurateURL = config.CurateURL
 	annote.FileStore.Root = config.UploadPath
+	annote.InitES(config.ElasticSearchURL)
 
 	annote.AnnotationStore = &annote.AnnoStore{
 		Host:             config.AnnotationStore,

--- a/cmd/annote-server/main.go
+++ b/cmd/annote-server/main.go
@@ -21,6 +21,7 @@ type Config struct {
 	AnnotationCredentials string
 	ImageViewerHost       string
 	Hostname              string
+	SolrHost              string
 	UploadPath            string
 	ElasticSearchURL      string
 }
@@ -74,6 +75,8 @@ func main() {
 		ImageViewerHost:  config.ImageViewerHost,
 		OurURL:           config.Hostname,
 	}
+
+	annote.Solr = &annote.SolrInfo{Host: config.SolrHost}
 
 	if config.TemplatePath != "" {
 		err := annote.LoadTemplates(config.TemplatePath)

--- a/internal/annote/annotation_server.go
+++ b/internal/annote/annotation_server.go
@@ -214,7 +214,7 @@ func (as *AnnoStore) sendRAP(rap *SubmitRAP) (rapResponse, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		log.Println("GET", url, "returned", resp.Status)
+		log.Println("POST", url, "returned", resp.Status)
 	}
 	// read the response...?
 	decoder := json.NewDecoder(resp.Body)

--- a/internal/annote/annotation_server.go
+++ b/internal/annote/annotation_server.go
@@ -69,6 +69,7 @@ func ParseNotWellformedTime(input string) time.Time {
 	// we try incresingly less specific formats until something matches
 	formats := []string{
 		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02Z",
 		"2006-01-02",
 		"2006-01",
 		"2006",
@@ -78,6 +79,7 @@ func ParseNotWellformedTime(input string) time.Time {
 		"1/2/06",
 		"January 2, 2006",
 		"January 2006",
+		"Jan-06",
 	}
 
 	for _, f := range formats {

--- a/internal/annote/db_mysql.go
+++ b/internal/annote/db_mysql.go
@@ -313,6 +313,17 @@ func (sq *MysqlDB) FindAllRange(offset, count int) ([]CurateItem, error) {
 	return readCurateItems(rows)
 }
 
+// support the Searcher interface
+
+func (sq *MysqlDB) Search(q SearchQuery) (SearchResults, error) {
+	items, err := sq.FindAllRange(q.Start, q.NumRows)
+	return SearchResults{Items: items}, err
+}
+func (sq *MysqlDB) IndexRecord(item CurateItem) {}
+func (sq *MysqlDB) IndexBatch(source Batcher)   {}
+
+// user things
+
 func (sq *MysqlDB) FindUser(username string) (*User, error) {
 	var u User
 	row := sq.db.QueryRow(`SELECT id, username, hashedpassword, created, orcid FROM users WHERE username = ? LIMIT 1`, username)

--- a/internal/annote/db_mysql.go
+++ b/internal/annote/db_mysql.go
@@ -171,7 +171,6 @@ func (sq *MysqlDB) SetConfig(key string, value string) error {
 	return err
 }
 
-// AllPurls returns a list of every purl in the database.
 func (sq *MysqlDB) IndexItem(item CurateItem) error {
 	tx, err := sq.db.Begin()
 	if err != nil {
@@ -286,6 +285,7 @@ func (sq *MysqlDB) FindCollectionMembers(pid string) ([]CurateItem, error) {
 	return readCurateItems(rows)
 }
 
+// FindAllRange returns a list of every purl in the database.
 func (sq *MysqlDB) FindAllRange(offset, count int) ([]CurateItem, error) {
 	// The deployed database is mysql 5.7, and there is no support for WITH
 	// statements or using LIMIT in IN subqueries. So we use an interesting

--- a/internal/annote/handlers.go
+++ b/internal/annote/handlers.go
@@ -457,10 +457,11 @@ type SearchQuery struct {
 }
 
 type SearchResults struct {
+	Total int
 	Items []CurateItem
 }
 
-type searchresults struct {
+type searchresultsPage struct {
 	Title      string
 	User       *User
 	Query      string
@@ -468,6 +469,7 @@ type searchresults struct {
 	NumPerPage int
 	StartIndex int
 	ItemList   []CurateItem
+	Total      int
 }
 
 var (
@@ -498,7 +500,7 @@ func SearchPage(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		return
 	}
 
-	output := searchresults{
+	output := searchresultsPage{
 		Title:      "Search",
 		User:       user,
 		Query:      query,
@@ -506,6 +508,7 @@ func SearchPage(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		NumPerPage: numperpage,
 		StartIndex: offset + 1,
 		ItemList:   results.Items,
+		Total:      results.Total,
 	}
 
 	DoTemplate(w, "search", output)

--- a/internal/annote/harvest.go
+++ b/internal/annote/harvest.go
@@ -65,6 +65,7 @@ func BackgroundHarvester() {
 				if err != nil {
 					log.Println(err)
 				}
+				IndexRecord(item)
 			}
 		}()
 		err := HarvestCurateObjects(TargetFedora, lastHarvest, func(item CurateItem) error {

--- a/internal/annote/harvest.go
+++ b/internal/annote/harvest.go
@@ -65,7 +65,7 @@ func BackgroundHarvester() {
 				if err != nil {
 					log.Println(err)
 				}
-				IndexRecord(item)
+				SearchEngine.IndexRecord(item)
 			}
 		}()
 		err := HarvestCurateObjects(TargetFedora, lastHarvest, func(item CurateItem) error {

--- a/internal/annote/index.go
+++ b/internal/annote/index.go
@@ -1,0 +1,167 @@
+package annote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/elastic/go-elasticsearch"
+	"github.com/elastic/go-elasticsearch/esapi"
+)
+
+var (
+	ESClient *elasticsearch.Client
+)
+
+func InitES(address string) {
+	var err error
+	ESClient, err = elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{address},
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 10 * time.Second,
+		},
+	})
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+func IndexRecord(item CurateItem) {
+	// Todo: reformat the item since the JSON form of a CurateItem datatype
+	// confuses elastic search.
+	// make it more like a json object.
+	b, err := json.Marshal(item.AsAlternate())
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	log.Println(string(b))
+
+	req := esapi.IndexRequest{
+		Index:      "items",
+		DocumentID: item.PID,
+		Refresh:    "true",
+		Body:       bytes.NewReader(b),
+	}
+
+	response, err := req.Do(context.Background(), ESClient)
+	if err != nil {
+		log.Println("index:", item.PID, err)
+		return
+	}
+	defer response.Body.Close()
+	log.Println(response)
+}
+
+// A Batcher provides a way to iterate through a (potentially very large) set of
+// CurateItems. Each time Batch() is called another subset of the set should be
+// returned. The empty list is returned when there is nothing left and signals
+// that the iteration is finished.
+type Batcher interface {
+	Batch() []CurateItem
+}
+
+// IndexBatch will index a lot of records. It is expected to be more
+// effecient than calling IndexRecord on each record.
+func IndexBatch(source Batcher) {
+	// Index in batches of 1000 items at a time
+	source = &Grouper{Goal: 1000, Source: source}
+
+	buf := &bytes.Buffer{}
+	count := 0
+	start := time.Now()
+	for {
+		items := source.Batch()
+		if len(items) == 0 {
+			break
+		}
+
+		buf.Reset()
+		for _, item := range items {
+			b, err := json.Marshal(item.AsAlternate())
+			if err != nil {
+				log.Println(item.PID, err)
+				continue
+			}
+			fmt.Fprintf(buf, `{"index":{"_id":"%s"}}`, item.PID)
+			buf.WriteString("\n")
+			buf.Write(b)
+			buf.WriteString("\n")
+			count++
+		}
+		// it would be nice to only set refresh to true on the
+		// last iteration. but we don't know which iteration
+		// will be the last beforehand.
+		req := esapi.BulkRequest{
+			Index:   "items",
+			Refresh: "true",
+			Body:    buf,
+		}
+
+		response, err := req.Do(context.Background(), ESClient)
+		if err != nil {
+			log.Println("batchindex:", err)
+			continue
+		}
+		log.Println(response)
+		response.Body.Close()
+	}
+	log.Println("BulkIndex", count, "Items", time.Now().Sub(start))
+}
+
+// A Grouper wraps a source Batcher and always returns lists containing Goal
+// number of items, except for the last one which may have less.
+type Grouper struct {
+	Goal   int
+	Source Batcher
+	done   bool
+	extra  []CurateItem
+}
+
+func (g *Grouper) Batch() []CurateItem {
+	if len(g.extra) == 0 && g.done {
+		return nil
+	}
+	result := g.extra
+	g.extra = nil
+	// Add items to be returned until we either have enough or are finished.
+	for len(result) < g.Goal && !g.done {
+		items := g.Source.Batch()
+		if len(items) == 0 {
+			g.done = true
+			break
+		}
+		result = append(result, items...)
+	}
+	if len(result) > g.Goal {
+		g.extra = make([]CurateItem, len(result)-g.Goal)
+		copy(g.extra, result[g.Goal:])
+		result = result[:g.Goal]
+	}
+	return result
+}
+
+// AllItems is a Batcher that will return everything in the database. It
+// returns Count items at a time, which if  equalt to 0 defaults to 500 items.
+type AllItems struct {
+	Offset int
+	Count  int
+}
+
+func (a *AllItems) Batch() []CurateItem {
+	if a.Count == 0 {
+		a.Count = 500
+	}
+	result, err := Datasource.FindAllRange(a.Offset, a.Count)
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+	a.Offset += a.Count
+	return result
+}

--- a/internal/annote/records.go
+++ b/internal/annote/records.go
@@ -20,6 +20,11 @@ type Pair struct {
 	Object    string
 }
 
+// A CurateItem holds the metadata record for a single collection, item, or
+// file. It consists of our local identifier for the item (with the namespace
+// prefix, if any), and then a sequence of field-value pairs. The field names
+// can repeat. The ordering of the pairs is only important among those having
+// the same field name.
 type CurateItem struct {
 	PID        string
 	Properties []Pair
@@ -54,6 +59,21 @@ func (c *CurateItem) RemoveAll(target string) {
 			i++
 		}
 	}
+}
+
+// A CurateItemAlt is an alternative representation of a CurateItem. It
+// consolidates each property field name into a map entry, and arranges the
+// (possibly multiple) values as a list. The PID is stored under the map entry
+// "PID".
+type CurateItemAlt map[string][]string
+
+func (c *CurateItem) AsAlternate() CurateItemAlt {
+	result := make(map[string][]string)
+	result["PID"] = []string{c.PID}
+	for _, p := range c.Properties {
+		result[p.Predicate] = append(result[p.Predicate], p.Object)
+	}
+	return CurateItemAlt(result)
 }
 
 type PredicatePair struct {

--- a/internal/annote/router.go
+++ b/internal/annote/router.go
@@ -20,6 +20,7 @@ func AddRoutes() http.Handler {
 		{"GET", "/obj", NotImplemented, true}, // legacy
 		{"GET", "/show/:id", ObjectShow, true},
 		{"GET", "/show/:id/annotate", ObjectAnnotate, true},
+		{"POST", "/show/:id/index", ObjectIndex, true},
 		{"GET", "/new", ObjectNew, true},
 		{"POST", "/new", ObjectNewPost, true},
 		{"GET", "/show/:id/edit", ObjectEdit, true},
@@ -27,6 +28,7 @@ func AddRoutes() http.Handler {
 		{"GET", "/downloads/:id/thumbnail", ObjectDownloadThumbnail, true},
 		{"GET", "/search", SearchPage, true},
 		{"GET", "/anno", ShowAnnotateStatus, true},
+		{"POST", "/index", IndexEverything, true},
 		{"GET", "/reset", ResetShow, false},
 		{"POST", "/reset", ResetUpdate, false},
 		{"GET", "/profile", ProfileShow, true},

--- a/internal/annote/solr.go
+++ b/internal/annote/solr.go
@@ -72,6 +72,111 @@ func (x *StringOrList) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (si *SolrInfo) Search(q SearchQuery) (SearchResults, error) {
+	var out SearchResults
+	results, err := si.SendQuery(SolrQuery{
+		Query: q.Query,
+		Start: q.Start,
+		Rows:  q.NumRows,
+		QueryFields: []string{
+			"desc_metadata__title_tesim",
+			"desc_metadata__name_tesim",
+			"noid_tsi",
+			"file_format_tesim",
+			"desc_metadata__contributor_tesim",
+			"desc_metadata__abstract_tesim",
+			"desc_metadata__description_tesim",
+			"desc_metadata__creator_tesim",
+			"desc_metadata__author_tesim",
+			"admin_unit_tesim",
+			"desc_metadata__publisher_tesim",
+			"desc_metadata__language_tesim",
+			"desc_metadata__collection_name_tesim",
+			"desc_metadata__contributor_institution_tesim",
+			"desc_metadata__subject_tesim",
+			"desc_metadata__identifier_sim",
+			"desc_metadata__urn_tesim",
+			"degree_name_tesim",
+			"degree_disciplines_tesim",
+			"contributors_tesim",
+			"degree_department_acronyms_tesim",
+			"desc_metadata__date_created_tesim",
+			"desc_metadata__source_tesim",
+			"desc_metadata__alephIdentifier_tesim",
+			"desc_metadata__patent_number_tesim",
+		},
+		FieldList: []string{
+			"id",
+			"desc_metadata__title_tesim",
+			"active_fedora_model_ssi",
+			"desc_metadata__creator_tesim",
+			"desc_metadata__description_tesim",
+			"desc_metadata__abstract_tesim",
+			"desc_metadata__date_created_tesim",
+			"admin_unit_tesim",
+			"representative_tesim",
+		},
+		Sort: []string{
+			"score desc",
+			"desc_metadata__date_uploaded_dtsi desc",
+		},
+		FilterQuery: []string{
+			"read_access_group_ssim:public", // only public things in prototype
+			"-active_fedora_model_ssi:Person",
+			"-active_fedora_model_ssi:FileAsset",
+			"-active_fedora_model_ssi:GenericFile",
+			"-active_fedora_model_ssi:Profile",
+			"-active_fedora_model_ssi:ProfileSection",
+			"-active_fedora_model_ssi:LinkedResource",
+			"-active_fedora_model_ssi:Hydramata_Group",
+		},
+	})
+	//log.Printf("solr %q", results)
+	if err != nil {
+		return out, err
+	}
+	out.Items = solrToCurateItem(results.Response.Docs)
+	return out, nil
+}
+
+var (
+	solrXlat = map[string]string{
+		"desc_metadata__title_tesim":        "dc:title",
+		"representative_tesim":              "representative",
+		"active_fedora_model_ssi":           "af-model",
+		"desc_metadata__creator_tesim":      "dc:creator",
+		"desc_metadata__description_tesim":  "dc:description",
+		"desc_metadata__abstract_tesim":     "dc:abstract",
+		"desc_metadata__date_created_tesim": "dc:created",
+		"admin_unit_tesim":                  "dc:creator#administrative_unit",
+	}
+)
+
+func solrToCurateItem(docs []map[string]StringOrList) []CurateItem {
+	var out []CurateItem
+	for _, doc := range docs {
+		item := CurateItem{}
+		for k, v := range doc {
+			vv := []string(v)
+			if k == "id" {
+				item.PID = vv[0]
+				continue
+			}
+			if kk, ok := solrXlat[k]; ok {
+				k = kk
+			}
+			for i := range vv {
+				item.Properties = append(item.Properties, Pair{
+					Predicate: k,
+					Object:    vv[i],
+				})
+			}
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
 func (si *SolrInfo) SendQuery(q SolrQuery) (SolrResponse, error) {
 	var result SolrResponse
 	params := url.Values{}
@@ -120,3 +225,7 @@ func (si *SolrInfo) SendQuery(q SolrQuery) (SolrResponse, error) {
 
 	return result, err
 }
+
+// IndexRecord and IndexBatch for Solr is not supported.
+func (si *SolrInfo) IndexRecord(item CurateItem) {}
+func (si *SolrInfo) IndexBatch(source Batcher)   {}

--- a/internal/annote/solr.go
+++ b/internal/annote/solr.go
@@ -1,0 +1,122 @@
+package annote
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SolrQuery struct {
+	Query       string
+	QueryFields []string
+	FieldList   []string
+	Start       int
+	Rows        int
+	Sort        []string
+	FilterQuery []string
+	Facets      []string
+}
+
+type SolrInfo struct {
+	Host string
+}
+
+var (
+	Solr *SolrInfo
+)
+
+type SolrResponse struct {
+	Response struct {
+		NumFound int                       `json:"numFound"`
+		Start    int                       `json:"start"`
+		MaxScore float32                   `json:"maxScore"`
+		Docs     []map[string]StringOrList `json:"docs"`
+	} `json:"response"`
+	//Facets struct {
+	//	FacetFields map[string][]StringCount `json:"facet_fields"`
+	//} `json:"facet_counts"`
+}
+
+// StringOrList is used to decode json documents having values
+// that may either be a string or a list of strings. It makes
+// everything a list of strings, so that we have a consistent
+// data type.
+type StringOrList []string
+
+func (x *StringOrList) UnmarshalJSON(b []byte) error {
+	// is it a list?
+	if b[0] == '[' {
+		return json.Unmarshal(b, (*[]string)(x))
+	}
+	// perhaps a string?
+	if b[0] == '"' {
+		var s string
+		err := json.Unmarshal(b, &s)
+		if err != nil {
+			return err
+		}
+		*x = []string{s}
+		return nil
+	}
+	// maybe it is a number??
+	var v float64
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	*x = []string{strconv.FormatFloat(v, 'f', 7, 64)}
+	return nil
+}
+
+func (si *SolrInfo) SendQuery(q SolrQuery) (SolrResponse, error) {
+	var result SolrResponse
+	params := url.Values{}
+
+	params.Add("q", q.Query)
+	if len(q.QueryFields) > 0 {
+		params.Add("qf", strings.Join(q.QueryFields, " "))
+	}
+	if len(q.FieldList) > 0 {
+		params.Add("fl", strings.Join(q.FieldList, ","))
+	}
+	params.Add("wt", "json")
+	params.Add("start", strconv.Itoa(q.Start))
+	params.Add("rows", strconv.Itoa(q.Rows))
+	params.Add("sort", strings.Join(q.Sort, ", "))
+	for _, fq := range q.FilterQuery {
+		params.Add("fq", fq)
+	}
+	for _, facet := range q.Facets {
+		params.Add("facet.field", facet)
+	}
+
+	u := si.Host + "?" + params.Encode()
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return result, err
+	}
+
+	if TimeoutClient == nil {
+		TimeoutClient = &http.Client{
+			Timeout: 60 * time.Minute,
+		}
+	}
+
+	resp, err := TimeoutClient.Do(req)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		log.Println("GET", u, "returned", resp.Status)
+	}
+	// read the response...?
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&result)
+
+	return result, err
+}

--- a/internal/annote/solr.go
+++ b/internal/annote/solr.go
@@ -152,6 +152,9 @@ var (
 	}
 )
 
+// solrToCurateItem translates the solr record we get into a CurateItem
+// for the search results. The curateitem we get is only an approximation
+// to the actual curate item. Use the database to get the definitive version of it.
 func solrToCurateItem(docs []map[string]StringOrList) []CurateItem {
 	var out []CurateItem
 	for _, doc := range docs {
@@ -159,12 +162,16 @@ func solrToCurateItem(docs []map[string]StringOrList) []CurateItem {
 		for k, v := range doc {
 			vv := []string(v)
 			if k == "id" {
+				// there is a special field for the PID
 				item.PID = vv[0]
 				continue
 			}
+			// Use the local translation of the field name if we have one.
 			if kk, ok := solrXlat[k]; ok {
 				k = kk
 			}
+			// The CurateItem is denormalized, so add an entry for each value we
+			// received from the solr record.
 			for i := range vv {
 				item.Properties = append(item.Properties, Pair{
 					Predicate: k,

--- a/web/templates/search
+++ b/web/templates/search
@@ -324,7 +324,7 @@
           </li>
 
           <span class="page_entries">
-            <strong>{{ .StartIndex }}</strong> - <strong>{{ add .StartIndex (len .ItemList) }}</strong> of <strong>13927</strong>
+            <strong>{{ .StartIndex }}</strong> - <strong>{{ add .StartIndex (len .ItemList) }}</strong> of <strong>{{ .Total }}</strong>
           </span>
           <li class="next-page ">
             <a href="/search?p={{ add .Page 1 }}&amp;n={{ .NumPerPage }}" rel="next">Next &raquo;</a>

--- a/web/templates/search
+++ b/web/templates/search
@@ -3,15 +3,51 @@
 <main id="main" role="main" class="page-main container search-results ">
   <div class="row">
     <div class="span9 offset3">
-      <form accept-charset="UTF-8" action="/search" class="search-form" method="get"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+      <form accept-charset="UTF-8" action="/search" class="search-form" method="get">
         <fieldset>
           <legend class="accessible-hidden">Search CurateND</legend>
           <label class="accessible-hidden" for="catalog_search">Search CurateND</label>
-          <input class="q search-query" id="catalog_search" name="q" placeholder="Search CurateND" size="30" tabindex="1" type="search" value="" />
+          <input class="q search-query" id="catalog_search" name="q" placeholder="Search CurateND" size="30" tabindex="1" type="search" value="{{ .Query }}" />
           <button type="submit" class="search-submit" id="keyword-search-submit">
             <img class="search-icon" src="/static/search.svg">
-            <span class="accessible-hidden">Search</span>
+            Search
           </button>
+
+          <div class="row sort-and-per-page">
+            <div class="choose-list-format">
+              <a href="" class="display-type listing active" title="Detail view">
+                <svg fill="#002b5b" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M4 14h4v-4H4v4zm0 5h4v-4H4v4zM4 9h4V5H4v4zm5 5h12v-4H9v4zm0 5h12v-4H9v4zM9 5v4h12V5H9z"/>
+                  <path d="M0 0h24v24H0z" fill="none"/>
+                </svg>
+              </a>
+              <a href="" class="display-type grid" title="Thumbnail view">
+                <svg fill="#002b5b" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M4 11h5V5H4v6zm0 7h5v-6H4v6zm6 0h5v-6h-5v6zm6 0h5v-6h-5v6zm-6-7h5V5h-5v6zm6-6v6h5V5h-5z"/>
+                  <path d="M0 0h24v24H0z" fill="none"/>
+                </svg>
+              </a>
+            </div>
+            <span class="sorting">
+
+              <select class="input-medium sort-per-page-dropdown" id="sort" name="sort">
+                <option value="">Sort by relevance</option>
+                <option value="created">Sort by newest date created</option>
+                <option value="createdR">Sort by oldest date created</option>
+                <option value="upload">Sort by newest upload</option>
+                <option value="uploadR">Sort by oldest upload</option>
+                <option value="mod">Sort by newest modification</option>
+                <option value="modR">Sort by oldest modification</option>
+              </select>
+
+              <select class="input-medium sort-per-page-dropdown" id="per_page" name="n" title="Number of results to display per page">
+                <option value="10">10 per page</option>
+                <option value="20" {{ if eq .NumPerPage 20 }}selected{{ end }}>20 per page</option>
+                <option value="50" {{ if eq .NumPerPage 50 }}selected{{ end }}>50 per page</option>
+                <option value="100" {{ if eq .NumPerPage 100 }}selected{{ end }}>100 per page</option>
+              </select>
+            </span>
+          </div>
         </fieldset>
       </form>
     </div>
@@ -234,52 +270,6 @@
     </div>
 
     <div class="span9 ">
-      <div class="row sort-and-per-page">
-        <div class="choose-list-format">
-          <a href="" class="display-type listing active" title="Detail view">
-            <svg fill="#002b5b" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M4 14h4v-4H4v4zm0 5h4v-4H4v4zM4 9h4V5H4v4zm5 5h12v-4H9v4zm0 5h12v-4H9v4zM9 5v4h12V5H9z"/>
-              <path d="M0 0h24v24H0z" fill="none"/>
-            </svg>
-          </a>
-          <a href="" class="display-type grid" title="Thumbnail view">
-            <svg fill="#002b5b" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M4 11h5V5H4v6zm0 7h5v-6H4v6zm6 0h5v-6h-5v6zm6 0h5v-6h-5v6zm-6-7h5V5h-5v6zm6-6v6h5V5h-5z"/>
-              <path d="M0 0h24v24H0z" fill="none"/>
-            </svg>
-          </a>
-        </div>
-
-
-        <form accept-charset="UTF-8" action="/search" class="sorting form-inline" method="get">
-
-          <span class="sorting">
-
-            <select class="input-medium sort-per-page-dropdown" id="sort" name="sort">
-              <option value="">Sort by relevance</option>
-              <option value="created">Sort by newest date created</option>
-              <option value="createdR">Sort by oldest date created</option>
-              <option value="upload">Sort by newest upload</option>
-              <option value="uploadR">Sort by oldest upload</option>
-              <option value="mod">Sort by newest modification</option>
-              <option value="modR">Sort by oldest modification</option></select>
-
-            <label for="per_page">
-              <select class="input-medium sort-per-page-dropdown" id="per_page" name="n" title="Number of results to display per page"><option value="10">10 per page</option>
-                <option value="20">20 per page</option>
-                <option value="50">50 per page</option>
-                <option value="100">100 per page</option>
-              </select>
-            </label>
-            <input name="q" type="hidden" value="" />
-            <button class="btn btn-primary submit-sort-per-page">
-              <i class="icon-refresh icon-white"></i> Update
-            </button>
-          </span>
-
-        </form>
-      </div>
-
       <h3 id="document-list-heading" class="accessible-hidden">List of files deposited in CurateND that match your search criteria</h3>
       <ul id="documents" class="container-fluid search-results-list" aria-labeled-by="document-list-heading">
         {{ $start := .StartIndex }}
@@ -311,7 +301,7 @@
               <dl class="attribute-list">
                 <dt>Author(s):</dt>
                 {{ with AllFields $item "dc:creator" }}
-                <dd>{{ . }}</dd>
+                <dd>{{ Join . ", " }}</dd>
                 {{ end }}
 
                 <dt>Abstract:</dt>


### PR DESCRIPTION
Add ability to use both Solr and Elastic Search for the search page. Also add ability to index content into ES. We treat solr as read only only since it was a stepping stone to getting search to work. If neither indexing service is configured we use the database just like we have always done.